### PR TITLE
Added macOS 13 Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import PackageDescription
 let package = Package(
     name: "skip-kit",
     defaultLocalization: "en",
-    platforms: [.iOS(.v16), .macOS(.v14), .tvOS(.v16), .watchOS(.v9), .macCatalyst(.v16)],
+    platforms: [.iOS(.v16), .macOS(.v13), .tvOS(.v16), .watchOS(.v9), .macCatalyst(.v16)],
     products: [
         .library(name: "SkipKit", targets: ["SkipKit"]),
     ],

--- a/Sources/SkipKit/AppInfo.swift
+++ b/Sources/SkipKit/AppInfo.swift
@@ -265,7 +265,7 @@ private let _deviceModel: String = {
     uname(&systemInfo)
     return withUnsafePointer(to: &systemInfo.machine) {
         $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-            String(validatingUTF8: $0) ?? "Unknown"
+            String(validatingCString: $0) ?? "Unknown"
         }
     }
     #else

--- a/Sources/SkipKit/DeviceInfo.swift
+++ b/Sources/SkipKit/DeviceInfo.swift
@@ -210,7 +210,7 @@ public final class DeviceInfo {
         uname(&systemInfo)
         return withUnsafePointer(to: &systemInfo.machine) {
             $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-                String(validatingUTF8: $0) ?? "Unknown"
+                String(validatingCString: $0) ?? "Unknown"
             }
         }
         #else

--- a/Sources/SkipKit/WebBrowser.swift
+++ b/Sources/SkipKit/WebBrowser.swift
@@ -126,7 +126,7 @@ extension View {
             }
             #elseif os(macOS)
             // macOS does not have SFSafariViewController; fall back to system browser
-            self.onChange(of: isPresented.wrappedValue) { oldPresented, newPresented in
+            self.onChange(of: isPresented.wrappedValue) { newPresented in
                 if newPresented {
                     NSWorkspace.shared.open(url)
                     isPresented.wrappedValue = false

--- a/Tests/SkipKitTests/SkipKitTests.swift
+++ b/Tests/SkipKitTests/SkipKitTests.swift
@@ -22,7 +22,7 @@ final class SkipKitTests: XCTestCase {
 
         var addedKeys = Set<UUID>()
         // Cache has no `count` accessor, so we brute-force check for the existance of every key we have added
-        var cacheCount = { addedKeys.compactMap({ cache[$0] }).count }
+        let cacheCount = { addedKeys.compactMap({ cache[$0] }).count }
 
         @discardableResult func addData(size: Int) -> UUID {
             let key = UUID()


### PR DESCRIPTION
This PR brings SkipKit's platform support in line with other Skip packages, such as SkipFoundation and SkipUI, which both support macOS 13. As a result, projects targeting macOS 13 can use SkipKit without requiring a newer deployment target.

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

