### PR TITLE
Create the CLLocationManager instance on the main thread

### DIFF
--- a/Sources/SkipKit/PermissionManager.swift
+++ b/Sources/SkipKit/PermissionManager.swift
@@ -395,7 +395,15 @@ class LocationDelegate: NSObject {
     static let accuracyAuthorizationReducedAccuracy = 1
 
     /// The shared `CLLocationManager` instance, or nil if the CoreLocation framework could not be loaded
-    lazy var locationManager: NSObject? = LocationDelegate.locationManagerClass()?.init()
+    lazy var locationManager: NSObject? = {
+        if Thread.isMainThread {
+            return LocationDelegate.locationManagerClass()?.init()
+        } else {
+            return DispatchQueue.main.asyncAndWait {
+                LocationDelegate.locationManagerClass()?.init()
+            }
+        }
+    }()
 
     var continuation: CheckedContinuation<Void, Never>?
 


### PR DESCRIPTION
Delegate methods need to have a thread with a RunLoop. This pull request should take care of that.

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

